### PR TITLE
Centralize DB path handling

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3,6 +3,7 @@ import aiosqlite
 import asyncio
 import os
 import logging
+from core.database import DB_PATH
 
 from datetime import datetime, timezone
 from config import client, DISCORD_TOKEN, perform_sync
@@ -10,15 +11,13 @@ from config import client, DISCORD_TOKEN, perform_sync
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-os.makedirs('./data/databases', exist_ok=True)
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Customisation Functions
 # ---------------------------------------------------------------------------------------------------------------------
 
 async def get_embed_colour():
-    async with aiosqlite.connect(db_path) as conn:
+    async with aiosqlite.connect(DB_PATH) as conn:
         async with conn.execute('SELECT value FROM customisation WHERE type = ?', ("embed_color",)) as cursor:
             row = await cursor.fetchone()
             if row:
@@ -26,7 +25,7 @@ async def get_embed_colour():
             return 0x3498db
 
 async def get_bio_settings():
-    async with aiosqlite.connect(db_path) as conn:
+    async with aiosqlite.connect(DB_PATH) as conn:
         async with conn.execute('SELECT value FROM customisation WHERE type = ?', ("activity_type",)) as cursor:
             activity_type_doc = await cursor.fetchone()
         async with conn.execute('SELECT value FROM customisation WHERE type = ?', ("bio",)) as cursor:

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -1,6 +1,7 @@
 import discord
 import aiosqlite
-import os
+
+from core.database import DB_PATH
 import logging
 
 from discord import app_commands
@@ -11,8 +12,6 @@ from core.utils import log_command_usage, check_permissions, get_embed_colour
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-os.makedirs('./data/databases', exist_ok=True)
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -40,7 +39,7 @@ class AdminCog(commands.Cog):
                 await interaction.followup.send("You do not have permission to use this command.", ephemeral=True)
                 return
 
-            async with aiosqlite.connect(db_path) as conn:
+            async with aiosqlite.connect(DB_PATH) as conn:
                 cursor = await conn.execute(
                     "SELECT sql FROM sqlite_master WHERE type='table' AND name = ?",
                     (table_name,)
@@ -71,7 +70,7 @@ class AdminCog(commands.Cog):
                 await interaction.followup.send("You do not have permission to use this command.", ephemeral=True)
                 return
 
-            async with aiosqlite.connect(db_path) as conn:
+            async with aiosqlite.connect(DB_PATH) as conn:
                 cursor = await conn.execute(
                     "SELECT name FROM sqlite_master WHERE type='table' AND name = ?",
                     (table_name,)

--- a/cogs/calendar.py
+++ b/cogs/calendar.py
@@ -1,6 +1,7 @@
 import logging
 import discord
-import aiosqlite
+
+from core.database import DB_PATH
 import calendar
 import os
 import io
@@ -19,8 +20,6 @@ BST = pytz.timezone("Europe/London")
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-os.makedirs('./data/databases', exist_ok=True)
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -132,7 +131,7 @@ class CalendarCog(commands.Cog):
         now_bst = datetime.now(BST)
         if not (now_bst.hour == 0 and now_bst.minute == 0):
             return
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             rows = await db.execute_fetchall("""
                     SELECT guild_id, channel_id, message_id, month, year
                     FROM calendar_views
@@ -169,7 +168,7 @@ class CalendarCog(commands.Cog):
 # ---------------------------------------------------------------------------------------------------------------------
     async def restore_calendar_views(self):
         try:
-            async with aiosqlite.connect(db_path) as db:
+            async with aiosqlite.connect(DB_PATH) as db:
                 cursor = await db.execute("SELECT guild_id, channel_id, message_id, month, year FROM calendar_views")
                 rows = await cursor.fetchall()
 
@@ -203,7 +202,7 @@ class CalendarCog(commands.Cog):
             logger.error(f"Error in restoring calendar views: {e}")
 
     async def autocomplete_calendar_title(self, interaction: discord.Interaction, current: str):
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             cursor = await db.execute("""
                 SELECT DISTINCT title FROM calendar_entries
                 WHERE guild_id = ? AND title LIKE ?
@@ -257,7 +256,7 @@ class CalendarCog(commands.Cog):
         draw.text((width // 2 - 10, 20 + th + 5), "💖", font=weekday_fnt, fill="black")
 
         # ─── Load events ─────────────────────────────────────────────────────────
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             c = await db.execute("""
                 SELECT title, date, emoji FROM calendar_entries
                 WHERE guild_id = ? AND title IS NOT NULL AND date IS NOT NULL
@@ -404,7 +403,7 @@ class CalendarCog(commands.Cog):
     @app_commands.command(name="set_calendar_channel", description="Admin: Set the channel for calendar posts.")
     async def set_calendar_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
         try:
-            async with aiosqlite.connect(db_path) as db:
+            async with aiosqlite.connect(DB_PATH) as db:
                 # Insert or update config row
                 await db.execute("""
                     INSERT OR REPLACE INTO calendar (guild_id, calendar_channel_id)
@@ -466,7 +465,7 @@ class CalendarCog(commands.Cog):
             return
 
         # fetch matching entries
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             cursor = await db.execute(
                 "SELECT emoji, title FROM calendar_entries "
                 "WHERE guild_id = ? AND date = ? "
@@ -527,7 +526,7 @@ class CalendarCog(commands.Cog):
 
             # Add all dates to the calendar_entries table
             days = (end_date - start_date).days + 1
-            async with aiosqlite.connect(db_path) as db:
+            async with aiosqlite.connect(DB_PATH) as db:
                 for i in range(days):
                     day = start_date + timedelta(days=i)
                     await db.execute("""
@@ -555,7 +554,7 @@ class CalendarCog(commands.Cog):
         try:
             await log_command_usage(self.bot, interaction)
 
-            async with aiosqlite.connect(db_path) as db:
+            async with aiosqlite.connect(DB_PATH) as db:
                 result = await db.execute("""
                     DELETE FROM calendar_entries
                     WHERE guild_id = ? AND title = ?
@@ -587,7 +586,7 @@ class CalendarCog(commands.Cog):
                                                             ephemeral=True)
                     return
 
-            async with aiosqlite.connect(db_path) as db:
+            async with aiosqlite.connect(DB_PATH) as db:
                 # Get existing entry
                 cursor = await db.execute("""
                     SELECT date, emoji FROM calendar_entries
@@ -623,7 +622,7 @@ class CalendarCog(commands.Cog):
 # Setup Function
 # ------------------------------------------------------------------------------------------------------------------
 async def setup(bot):
-    async with aiosqlite.connect(db_path) as db:
+    async with aiosqlite.connect(DB_PATH) as db:
         await db.execute('''
             CREATE TABLE IF NOT EXISTS calendar (
                 guild_id INTEGER,

--- a/cogs/conversation starter.py
+++ b/cogs/conversation starter.py
@@ -3,7 +3,8 @@ import logging
 import asyncio
 import random
 import pytz
-import aiosqlite
+
+from core.database import DB_PATH
 import json
 import os
 
@@ -15,8 +16,6 @@ from core.utils import get_embed_colour, log_command_usage
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-os.makedirs('./data/databases', exist_ok=True)
-db_path = './data/databases/pebble.db'
 prompt_file = './data/prompt_bank/prompts.json'
 BST_TIMEZONE = pytz.timezone("Europe/London")
 
@@ -61,7 +60,7 @@ class ConversationCog(commands.Cog):
 
         prompt_text = random.choice(prompts)
 
-        async with aiosqlite.connect(db_path) as conn:
+        async with aiosqlite.connect(DB_PATH) as conn:
             cursor = await conn.execute('''
                 SELECT guild_id, prompt_channel_id
                 FROM config
@@ -91,7 +90,7 @@ class ConversationCog(commands.Cog):
                 await interaction.response.send_message("Error: You don't have permission to set that channel.", ephemeral=True)
                 return
 
-            async with aiosqlite.connect(db_path) as conn:
+            async with aiosqlite.connect(DB_PATH) as conn:
                 await conn.execute('''
                     INSERT INTO config (guild_id, prompt_channel_id)
                     VALUES (?, ?)

--- a/cogs/customisation.py
+++ b/cogs/customisation.py
@@ -1,7 +1,7 @@
 import discord
 import logging
-import aiosqlite
-import os
+
+from core.database import DB_PATH
 from discord import app_commands
 from discord.ext import commands
 from discord.ext.commands import has_permissions
@@ -11,8 +11,6 @@ from core.utils import log_command_usage, check_permissions
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-os.makedirs('./data/databases', exist_ok=True)
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -27,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 async def get_bio_settings():
     try:
-        async with aiosqlite.connect(db_path) as conn:
+        async with aiosqlite.connect(DB_PATH) as conn:
             async with conn.execute('SELECT value FROM customisation WHERE type = ?', ("activity_type",)) as cursor:
                 activity_type_doc = await cursor.fetchone()
             async with conn.execute('SELECT value FROM customisation WHERE type = ?', ("bio",)) as cursor:
@@ -80,7 +78,7 @@ class CustomisationCog(commands.Cog):
                                                     ephemeral=True)
             return
 
-        async with aiosqlite.connect(db_path) as conn:
+        async with aiosqlite.connect(DB_PATH) as conn:
             try:
                 if colour.startswith("#"):
                     color = colour[1:]
@@ -124,7 +122,7 @@ class CustomisationCog(commands.Cog):
             await interaction.response.send_message("You do not have permission to use this command.", ephemeral=True)
             return
 
-        async with aiosqlite.connect(db_path) as conn:
+        async with aiosqlite.connect(DB_PATH) as conn:
             try:
                 if activity_type.lower() == "playing":
                     activity = discord.Game(name=bio)
@@ -167,7 +165,7 @@ class CustomisationCog(commands.Cog):
 # ---------------------------------------------------------------------------------------------------------------------
 
 async def setup(bot):
-    async with aiosqlite.connect(db_path) as conn:
+    async with aiosqlite.connect(DB_PATH) as conn:
         await conn.execute('''
         CREATE TABLE IF NOT EXISTS customisation (
             id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/cogs/game - rps.py
+++ b/cogs/game - rps.py
@@ -1,5 +1,6 @@
 import discord
-import aiosqlite
+
+from core.database import DB_PATH
 import logging
 
 from discord import app_commands
@@ -11,7 +12,6 @@ from core.utils import check_permissions, log_command_usage
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -93,7 +93,7 @@ class GameView(View):
 
     async def update_leaderboard(self, guild_id, winner_id, loser_id, draw=False):
         game_name = "RPS"
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             if draw:
                 await db.execute(
                     "INSERT INTO leaderboards (guild_id, game, user_id, draws) VALUES (?, ?, ?, 1) "
@@ -258,7 +258,7 @@ class RPSCog(commands.Cog):
 # Setup Function
 # ---------------------------------------------------------------------------------------------------------------------
 async def setup(bot):
-    async with aiosqlite.connect(db_path) as conn:
+    async with aiosqlite.connect(DB_PATH) as conn:
         await conn.execute('''
             CREATE TABLE IF NOT EXISTS leaderboards (
                 guild_id INTEGER,

--- a/cogs/game - tictactoe.py
+++ b/cogs/game - tictactoe.py
@@ -1,6 +1,7 @@
 import random
 import discord
-import aiosqlite
+
+from core.database import DB_PATH
 import logging
 
 from discord import app_commands
@@ -12,7 +13,6 @@ from core.utils import check_permissions, log_command_usage
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -138,7 +138,7 @@ class GameView(View):
 
     async def update_leaderboard(self, guild_id, winner_id, loser_id, draw=False):
         game_name = "TicTacToe"
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             if draw:
                 await db.execute(
                     "INSERT INTO leaderboards (guild_id, game, user_id, draws) VALUES (?, ?, ?, 1) "
@@ -285,7 +285,7 @@ class TicTacToe(commands.Cog):
 # Setup Function
 # ---------------------------------------------------------------------------------------------------------------------
 async def setup(bot):
-    async with aiosqlite.connect(db_path) as conn:
+    async with aiosqlite.connect(DB_PATH) as conn:
         await conn.execute('''
             CREATE TABLE IF NOT EXISTS leaderboards (
                 guild_id INTEGER,

--- a/cogs/important_dates.py
+++ b/cogs/important_dates.py
@@ -1,7 +1,7 @@
 import discord
-import aiosqlite
+
+from core.database import DB_PATH
 import logging
-import os
 
 from discord import app_commands
 from discord.ext import commands
@@ -12,8 +12,6 @@ from core.utils import log_command_usage, check_permissions, get_embed_colour
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-os.makedirs('./data/databases', exist_ok=True)
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -65,7 +63,7 @@ class ImportantDatesCog(commands.Cog):
 
             message = await channel.send(embed=embed)
 
-            async with aiosqlite.connect(db_path) as conn:
+            async with aiosqlite.connect(DB_PATH) as conn:
                 await conn.execute('''
                     INSERT INTO dates (guild_id, type, value)
                     VALUES (?, 'channel', ?)
@@ -98,7 +96,7 @@ class ImportantDatesCog(commands.Cog):
                                                         ephemeral=True)
                 return
 
-            async with aiosqlite.connect(db_path) as conn:
+            async with aiosqlite.connect(DB_PATH) as conn:
                 cursor = await conn.execute('SELECT value FROM dates WHERE guild_id = ? AND type = ?',
                                             (interaction.guild.id, 'channel'))
                 channel_row = await cursor.fetchone()
@@ -149,7 +147,7 @@ class ImportantDatesCog(commands.Cog):
     @app_commands.command(name="remove_date", description="User: Remove a date manually by editing the embed.")
     async def remove_date(self, interaction: discord.Interaction, index: int):
         try:
-            async with aiosqlite.connect(db_path) as conn:
+            async with aiosqlite.connect(DB_PATH) as conn:
                 cursor = await conn.execute('SELECT value FROM dates WHERE guild_id = ? AND type = ?', (interaction.guild.id, 'channel'))
                 channel_row = await cursor.fetchone()
                 cursor = await conn.execute('SELECT value FROM dates WHERE guild_id = ? AND type = ?', (interaction.guild.id, 'message_id'))
@@ -200,7 +198,7 @@ class ImportantDatesCog(commands.Cog):
                     await interaction.response.send_message("Error: Invalid date format. Use DD/MM/YYYY.", ephemeral=True)
                     return
 
-            async with aiosqlite.connect(db_path) as conn:
+            async with aiosqlite.connect(DB_PATH) as conn:
                 cursor = await conn.execute('SELECT value FROM dates WHERE guild_id = ? AND type = ?', (interaction.guild.id, 'channel'))
                 channel_row = await cursor.fetchone()
                 cursor = await conn.execute('SELECT value FROM dates WHERE guild_id = ? AND type = ?', (interaction.guild.id, 'message_id'))
@@ -256,7 +254,7 @@ class ImportantDatesCog(commands.Cog):
 # Setup
 # ------------------------------------------------------------------------------------------------------------------
 async def setup(bot):
-    async with aiosqlite.connect(db_path) as conn:
+    async with aiosqlite.connect(DB_PATH) as conn:
         await conn.execute('''
             CREATE TABLE IF NOT EXISTS dates (
                 guild_id INTEGER,

--- a/cogs/music_player.py
+++ b/cogs/music_player.py
@@ -6,7 +6,8 @@ import os
 import random
 import validators
 import yt_dlp as youtube_dl
-import aiosqlite
+
+from core.database import DB_PATH
 import logging
 import asyncio
 
@@ -19,7 +20,6 @@ from core.utils import check_permissions, log_command_usage
 # ---------------------------------------------------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------------------------------------------------
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging
@@ -268,7 +268,7 @@ class MusicPlayer(commands.Cog):
 
     async def autocomplete_playlists(self, interaction: discord.Interaction, current: str):
         user_id = str(interaction.user.id)
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             cursor = await db.execute(
                 "SELECT name FROM playlists WHERE user_id = ? AND name LIKE ?",
                 (user_id, f'%{current}%')
@@ -284,7 +284,7 @@ class MusicPlayer(commands.Cog):
         await self.load_progress_images()
 
     async def load_progress_images(self):
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             cursor = await db.execute('SELECT percentage, url FROM progress_bars')
             rows = await cursor.fetchall()
             self.progress_bar_images = {str(row[0]): row[1] for row in rows}
@@ -348,7 +348,7 @@ class MusicPlayer(commands.Cog):
 
     async def generate_and_upload_progress_images(self):
         channel = self.bot.get_channel(1359480363725885470)
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             await db.execute('DELETE FROM progress_bars')
 
             for i in range(101):  # Loop through percentages 0 to 100
@@ -737,7 +737,7 @@ class MusicPlayer(commands.Cog):
             return
 
         user_id = str(interaction.user.id)
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             cursor = await db.execute(
                 "SELECT title, url FROM songs WHERE user_id = ? AND playlist_name = ?",
                 (user_id, playlist_name)
@@ -789,7 +789,7 @@ class MusicPlayer(commands.Cog):
 #  Setup Function
 #  ---------------------------------------------------------------------------------------------------------------------
 async def setup(bot):
-    async with aiosqlite.connect(db_path) as db:
+    async with aiosqlite.connect(DB_PATH) as db:
         await db.execute('''
             CREATE TABLE IF NOT EXISTS playlists (
                 user_id TEXT,

--- a/cogs/setup.py
+++ b/cogs/setup.py
@@ -1,8 +1,8 @@
 
 import logging
 import discord
-import aiosqlite
-import os
+
+from core.database import DB_PATH
 import re
 
 from discord.ext import commands
@@ -12,8 +12,6 @@ from core.utils import log_command_usage
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-os.makedirs('./data/databases', exist_ok=True)
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -64,7 +62,7 @@ class SetupCog(commands.Cog):
                 "Garden": ["adventures", "gallery"]
             }
 
-            async with aiosqlite.connect(db_path) as conn:
+            async with aiosqlite.connect(DB_PATH) as conn:
                 for cat_name, channels in categories.items():
                     category = discord.utils.get(guild.categories, name=cat_name)
                     if not category:
@@ -116,7 +114,7 @@ class SetupCog(commands.Cog):
 # Setup Function
 # ---------------------------------------------------------------------------------------------------------------------
 async def setup(bot):
-    async with aiosqlite.connect(db_path) as conn:
+    async with aiosqlite.connect(DB_PATH) as conn:
         # Config table
         await conn.execute('''
             CREATE TABLE IF NOT EXISTS config (

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ from discord.ext import commands
 from dotenv import load_dotenv
 
 from discord.ext.commands import is_owner, Context
+from core.database import DB_PATH
 
 # Loads the .env file that resides on the same level as the script
 load_dotenv("config.env.txt")
@@ -27,7 +28,7 @@ intents.message_content = True
 # Ensure the necessary directories exist
 os.makedirs('data', exist_ok=True)
 os.makedirs('data/logs', exist_ok=True)
-os.makedirs('data/databases', exist_ok=True)
+os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
 os.makedirs('data/prompt_bank', exist_ok=True)
 os.makedirs('data/fonts', exist_ok=True)
 

--- a/core/database.py
+++ b/core/database.py
@@ -1,0 +1,3 @@
+"""Database configuration constants."""
+
+DB_PATH = './data/databases/pebble.db'

--- a/core/initialisation.py
+++ b/core/initialisation.py
@@ -1,7 +1,7 @@
 import discord
-import os
 import datetime
 import aiosqlite
+from core.database import DB_PATH
 import logging
 
 from discord import app_commands
@@ -13,8 +13,6 @@ from config import client
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-os.makedirs('./data/databases', exist_ok=True)
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -35,7 +33,7 @@ class TheMachineBotCore(commands.Cog):
     @commands.Cog.listener()
     async def on_ready(self):
         print(f'Logged on as {self.bot.user}...')
-        async with aiosqlite.connect(db_path) as conn:
+        async with aiosqlite.connect(DB_PATH) as conn:
             async with conn.execute('SELECT value FROM customisation WHERE type = ?', ("activity_type",)) as cursor:
                 activity_type_doc = await cursor.fetchone()
             async with conn.execute('SELECT value FROM customisation WHERE type = ?', ("bio",)) as cursor:

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,15 +1,13 @@
 import discord
-import os
 import logging
 import aiosqlite
+from core.database import DB_PATH
 from functools import wraps
 from discord.ui import View, Button
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-os.makedirs('./data/databases', exist_ok=True)
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -23,7 +21,7 @@ logger = logging.getLogger(__name__)
 async def get_embed_colour(guild_id):
     try:
         guild_id = int(guild_id)
-        async with aiosqlite.connect(db_path) as conn:
+        async with aiosqlite.connect(DB_PATH) as conn:
             async with conn.execute(
                 'SELECT value FROM customisation WHERE type = ? AND guild_id = ?',
                 ("embed_color", guild_id)
@@ -60,8 +58,8 @@ async def log_command_usage(bot, interaction):
         log_channel = None
 
         if guild:
-            async with aiosqlite.connect(db_path) as conn:
-                logger.info(f"Connected to the database at {db_path}")
+            async with aiosqlite.connect(DB_PATH) as conn:
+                logger.info(f"Connected to the database at {DB_PATH}")
                 async with conn.execute(
                     'SELECT log_channel_id FROM config WHERE guild_id = ?', (guild.id,)
                 ) as cursor:
@@ -111,7 +109,7 @@ async def check_permissions(interaction):
     if interaction.user.guild_permissions.administrator:
         return True
 
-    async with aiosqlite.connect(db_path) as conn:
+    async with aiosqlite.connect(DB_PATH) as conn:
         cursor = await conn.execute('''
             SELECT can_use_commands FROM permissions WHERE guild_id = ? AND user_id = ?
         ''', (interaction.guild_id, interaction.user.id))


### PR DESCRIPTION
## Summary
- add `core/database.py` with a single `DB_PATH` constant
- reference `DB_PATH` from config and all cogs
- remove individual database path constants and directory creation calls

## Testing
- `python -m py_compile $(find . -name '*.py' -print)`

------
https://chatgpt.com/codex/tasks/task_e_684567ebdfe48323858dd8c76e18ad69