### PR TITLE
Centralize database path helper

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6,19 +6,18 @@ import logging
 
 from datetime import datetime, timezone
 from config import client, DISCORD_TOKEN, perform_sync
+from core.utils import DB_PATH
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-os.makedirs('./data/databases', exist_ok=True)
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Customisation Functions
 # ---------------------------------------------------------------------------------------------------------------------
 
 async def get_embed_colour():
-    async with aiosqlite.connect(db_path) as conn:
+    async with aiosqlite.connect(DB_PATH) as conn:
         async with conn.execute('SELECT value FROM customisation WHERE type = ?', ("embed_color",)) as cursor:
             row = await cursor.fetchone()
             if row:
@@ -26,7 +25,7 @@ async def get_embed_colour():
             return 0x3498db
 
 async def get_bio_settings():
-    async with aiosqlite.connect(db_path) as conn:
+    async with aiosqlite.connect(DB_PATH) as conn:
         async with conn.execute('SELECT value FROM customisation WHERE type = ?', ("activity_type",)) as cursor:
             activity_type_doc = await cursor.fetchone()
         async with conn.execute('SELECT value FROM customisation WHERE type = ?', ("bio",)) as cursor:

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -1,18 +1,15 @@
 import discord
 import aiosqlite
-import os
 import logging
 
 from discord import app_commands
 from discord.ext import commands
 from config import client, perform_sync
-from core.utils import log_command_usage, check_permissions, get_embed_colour
+from core.utils import log_command_usage, check_permissions, get_embed_colour, DB_PATH
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-os.makedirs('./data/databases', exist_ok=True)
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -39,7 +36,7 @@ class AdminCog(commands.Cog):
                 await interaction.followup.send("You do not have permission to use this command.", ephemeral=True)
                 return
 
-            async with aiosqlite.connect(db_path) as conn:
+            async with aiosqlite.connect(DB_PATH) as conn:
                 cursor = await conn.execute(
                     "SELECT sql FROM sqlite_master WHERE type='table' AND name = ?",
                     (table_name,)
@@ -70,7 +67,7 @@ class AdminCog(commands.Cog):
                 await interaction.followup.send("You do not have permission to use this command.", ephemeral=True)
                 return
 
-            async with aiosqlite.connect(db_path) as conn:
+            async with aiosqlite.connect(DB_PATH) as conn:
                 cursor = await conn.execute(
                     "SELECT name FROM sqlite_master WHERE type='table' AND name = ?",
                     (table_name,)

--- a/cogs/conversation_starter.py
+++ b/cogs/conversation_starter.py
@@ -10,13 +10,11 @@ import os
 from discord import app_commands
 from discord.ext import commands, tasks
 from datetime import datetime
-from core.utils import get_embed_colour, log_command_usage
+from core.utils import get_embed_colour, log_command_usage, DB_PATH
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-os.makedirs('./data/databases', exist_ok=True)
-db_path = './data/databases/pebble.db'
 prompt_file = './data/prompt_bank/prompts.json'
 
 prompt_file = './prompt_bank/prompts.json'
@@ -65,7 +63,7 @@ class ConversationCog(commands.Cog):
 
         prompt_text = random.choice(prompts)
 
-        async with aiosqlite.connect(db_path) as conn:
+        async with aiosqlite.connect(DB_PATH) as conn:
             cursor = await conn.execute('''
                 SELECT guild_id, prompt_channel_id
                 FROM config
@@ -95,7 +93,7 @@ class ConversationCog(commands.Cog):
                 await interaction.response.send_message("Error: You don't have permission to set that channel.", ephemeral=True)
                 return
 
-            async with aiosqlite.connect(db_path) as conn:
+            async with aiosqlite.connect(DB_PATH) as conn:
                 await conn.execute('''
                     INSERT INTO config (guild_id, prompt_channel_id)
                     VALUES (?, ?)

--- a/cogs/countdowns.py
+++ b/cogs/countdowns.py
@@ -5,19 +5,16 @@ import aiohttp
 import logging
 import pytz
 import re
-import os
 
 from datetime import datetime, timedelta
 from discord.ext import commands, tasks
 from discord import app_commands
 
-from core.utils import log_command_usage, get_embed_colour
+from core.utils import log_command_usage, get_embed_colour, DB_PATH
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-os.makedirs('./data/databases', exist_ok=True)
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -58,7 +55,7 @@ class CancelCountdownButton(discord.ui.View):
         if not interaction.user.guild_permissions.administrator:
             await interaction.response.send_message("Only admins can cancel countdowns.", ephemeral=True)
             return
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             await db.execute("DELETE FROM countdowns WHERE guild_id = ? AND user_id = ? AND name = ?",
                              (self.guild_id, self.user_id, self.name))
             await db.commit()
@@ -140,7 +137,7 @@ class CountdownCog(commands.Cog):
 
             embed.set_thumbnail(url=self.bot.user.display_avatar.url)
 
-            async with aiosqlite.connect(db_path) as db:
+            async with aiosqlite.connect(DB_PATH) as db:
                 cursor = await db.execute("SELECT countdown_channel_id FROM config WHERE guild_id = ?",
                                           (interaction.guild.id,))
                 row = await cursor.fetchone()
@@ -156,7 +153,7 @@ class CountdownCog(commands.Cog):
                 }
                 channel = await interaction.guild.create_text_channel('countdowns', overwrites=overwrites)
 
-                async with aiosqlite.connect(db_path) as db:
+                async with aiosqlite.connect(DB_PATH) as db:
                     await db.execute('''
                         INSERT INTO config (guild_id, countdown_channel_id)
                         VALUES (?, ?)
@@ -167,7 +164,7 @@ class CountdownCog(commands.Cog):
             view = CancelCountdownButton(self.bot, interaction.guild.id, interaction.user.id, name)
             message = await channel.send(embed=embed, view=view)
 
-            async with aiosqlite.connect(db_path) as db:
+            async with aiosqlite.connect(DB_PATH) as db:
                 await db.execute('''
                     INSERT OR REPLACE INTO countdowns (guild_id, user_id, name, date, warned, channel_id, message_id)
                     VALUES (?, ?, ?, ?, 0, ?, ?)
@@ -192,7 +189,7 @@ class CountdownCog(commands.Cog):
                 await interaction.response.send_message("Only admins can set the countdown channel.", ephemeral=True)
                 return
 
-            async with aiosqlite.connect(db_path) as db:
+            async with aiosqlite.connect(DB_PATH) as db:
                 await db.execute('''
                     INSERT INTO config (guild_id, countdown_channel_id)
                     VALUES (?, ?)
@@ -213,7 +210,7 @@ class CountdownCog(commands.Cog):
     @app_commands.command(name="countdown_list", description="User: See your active countdowns.")
     async def countdown_list(self, interaction: discord.Interaction):
         try:
-            async with aiosqlite.connect(db_path) as db:
+            async with aiosqlite.connect(DB_PATH) as db:
                 rows = await db.execute_fetchall('''
                     SELECT name, date FROM countdowns
                     WHERE guild_id = ? AND user_id = ?
@@ -250,7 +247,7 @@ class CountdownCog(commands.Cog):
     # ---------------------------------------------------------------------------------------------------------------------
     async def resume_active_countdowns(self):
         await self.bot.wait_until_ready()
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             rows = await db.execute_fetchall('''
                 SELECT guild_id, user_id, name, date, channel_id, message_id
                 FROM countdowns
@@ -336,7 +333,7 @@ class CountdownCog(commands.Cog):
     async def countdown_check(self):
         now = datetime.utcnow()
         warning_threshold = now + timedelta(hours=24)
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             rows = await db.execute_fetchall('''
                 SELECT guild_id, user_id, name, date FROM countdowns
                 WHERE warned = 0 AND date <= ?
@@ -363,7 +360,7 @@ class CountdownCog(commands.Cog):
 # SETUP FUNCTION
 # ---------------------------------------------------------------------------------------------------------------------
 async def setup(bot):
-    async with aiosqlite.connect(db_path) as db:
+    async with aiosqlite.connect(DB_PATH) as db:
         await db.execute('''
             CREATE TABLE IF NOT EXISTS countdowns (
                 guild_id INTEGER,

--- a/cogs/customisation.py
+++ b/cogs/customisation.py
@@ -1,18 +1,15 @@
 import discord
 import logging
 import aiosqlite
-import os
 from discord import app_commands
 from discord.ext import commands
 from discord.ext.commands import has_permissions
 
-from core.utils import log_command_usage, check_permissions
+from core.utils import log_command_usage, check_permissions, DB_PATH
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-os.makedirs('./data/databases', exist_ok=True)
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -26,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 async def get_bio_settings():
     try:
-        async with aiosqlite.connect(db_path) as conn:
+        async with aiosqlite.connect(DB_PATH) as conn:
             async with conn.execute('SELECT value FROM customisation WHERE type = ?', ("activity_type",)) as cursor:
                 activity_type_doc = await cursor.fetchone()
             async with conn.execute('SELECT value FROM customisation WHERE type = ?', ("bio",)) as cursor:
@@ -79,7 +76,7 @@ class CustomisationCog(commands.Cog):
                                                     ephemeral=True)
             return
 
-        async with aiosqlite.connect(db_path) as conn:
+        async with aiosqlite.connect(DB_PATH) as conn:
             try:
                 if colour.startswith("#"):
                     color = colour[1:]
@@ -123,7 +120,7 @@ class CustomisationCog(commands.Cog):
             await interaction.response.send_message("You do not have permission to use this command.", ephemeral=True)
             return
 
-        async with aiosqlite.connect(db_path) as conn:
+        async with aiosqlite.connect(DB_PATH) as conn:
             try:
                 if activity_type.lower() == "playing":
                     activity = discord.Game(name=bio)
@@ -166,7 +163,7 @@ class CustomisationCog(commands.Cog):
 # ---------------------------------------------------------------------------------------------------------------------
 
 async def setup(bot):
-    async with aiosqlite.connect(db_path) as conn:
+    async with aiosqlite.connect(DB_PATH) as conn:
         await conn.execute('''
         CREATE TABLE IF NOT EXISTS customisation (
             id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/cogs/game_rps.py
+++ b/cogs/game_rps.py
@@ -6,12 +6,11 @@ from discord import app_commands
 from discord.ext import commands
 from discord.ui import Button, View
 
-from core.utils import check_permissions, log_command_usage
+from core.utils import check_permissions, log_command_usage, DB_PATH
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -92,7 +91,7 @@ class GameView(View):
 
     async def update_leaderboard(self, guild_id, winner_id, loser_id, draw=False):
         game_name = "RPS"
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             if draw:
                 await db.execute(
                     "INSERT INTO leaderboards (guild_id, game, user_id, draws) VALUES (?, ?, ?, 1) "
@@ -257,7 +256,7 @@ class RPSCog(commands.Cog):
 # Setup Function
 # ---------------------------------------------------------------------------------------------------------------------
 async def setup(bot):
-    async with aiosqlite.connect(db_path) as conn:
+    async with aiosqlite.connect(DB_PATH) as conn:
         await conn.execute('''
             CREATE TABLE IF NOT EXISTS leaderboards (
                 guild_id INTEGER,

--- a/cogs/game_tictactoe.py
+++ b/cogs/game_tictactoe.py
@@ -7,12 +7,11 @@ from discord import app_commands
 from discord.ext import commands
 from discord.ui import Button, View
 
-from core.utils import check_permissions, log_command_usage
+from core.utils import check_permissions, log_command_usage, DB_PATH
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -137,7 +136,7 @@ class GameView(View):
 
     async def update_leaderboard(self, guild_id, winner_id, loser_id, draw=False):
         game_name = "TicTacToe"
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             if draw:
                 await db.execute(
                     "INSERT INTO leaderboards (guild_id, game, user_id, draws) VALUES (?, ?, ?, 1) "
@@ -284,7 +283,7 @@ class TicTacToe(commands.Cog):
 # Setup Function
 # ---------------------------------------------------------------------------------------------------------------------
 async def setup(bot):
-    async with aiosqlite.connect(db_path) as conn:
+    async with aiosqlite.connect(DB_PATH) as conn:
         await conn.execute('''
             CREATE TABLE IF NOT EXISTS leaderboards (
                 guild_id INTEGER,

--- a/cogs/music_player.py
+++ b/cogs/music_player.py
@@ -14,12 +14,11 @@ from PIL import Image, ImageDraw
 from discord.ext import commands, tasks
 from discord import app_commands
 
-from core.utils import check_permissions, log_command_usage
+from core.utils import check_permissions, log_command_usage, DB_PATH
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------------------------------------------------
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging
@@ -267,7 +266,7 @@ class MusicPlayer(commands.Cog):
 
     async def autocomplete_playlists(self, interaction: discord.Interaction, current: str):
         user_id = str(interaction.user.id)
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             cursor = await db.execute(
                 "SELECT name FROM playlists WHERE user_id = ? AND name LIKE ?",
                 (user_id, f'%{current}%')
@@ -283,7 +282,7 @@ class MusicPlayer(commands.Cog):
         await self.load_progress_images()
 
     async def load_progress_images(self):
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             cursor = await db.execute('SELECT percentage, url FROM progress_bars')
             rows = await cursor.fetchall()
             self.progress_bar_images = {str(row[0]): row[1] for row in rows}
@@ -347,7 +346,7 @@ class MusicPlayer(commands.Cog):
 
     async def generate_and_upload_progress_images(self):
         channel = self.bot.get_channel(1359480363725885470)
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             await db.execute('DELETE FROM progress_bars')
 
             for i in range(101):  # Loop through percentages 0 to 100
@@ -736,7 +735,7 @@ class MusicPlayer(commands.Cog):
             return
 
         user_id = str(interaction.user.id)
-        async with aiosqlite.connect(db_path) as db:
+        async with aiosqlite.connect(DB_PATH) as db:
             cursor = await db.execute(
                 "SELECT title, url FROM songs WHERE user_id = ? AND playlist_name = ?",
                 (user_id, playlist_name)
@@ -788,7 +787,7 @@ class MusicPlayer(commands.Cog):
 #  Setup Function
 #  ---------------------------------------------------------------------------------------------------------------------
 async def setup(bot):
-    async with aiosqlite.connect(db_path) as db:
+    async with aiosqlite.connect(DB_PATH) as db:
         await db.execute('''
             CREATE TABLE IF NOT EXISTS playlists (
                 user_id TEXT,

--- a/cogs/setup.py
+++ b/cogs/setup.py
@@ -2,18 +2,15 @@
 import logging
 import discord
 import aiosqlite
-import os
 import re
 
 from discord.ext import commands
 from discord import app_commands
-from core.utils import log_command_usage
+from core.utils import log_command_usage, DB_PATH
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-os.makedirs('./data/databases', exist_ok=True)
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -63,7 +60,7 @@ class SetupCog(commands.Cog):
                 "Garden": ["adventures", "gallery"]
             }
 
-            async with aiosqlite.connect(db_path) as conn:
+            async with aiosqlite.connect(DB_PATH) as conn:
                 for cat_name, channels in categories.items():
                     category = discord.utils.get(guild.categories, name=cat_name)
                     if not category:
@@ -115,7 +112,7 @@ class SetupCog(commands.Cog):
 # Setup Function
 # ---------------------------------------------------------------------------------------------------------------------
 async def setup(bot):
-    async with aiosqlite.connect(db_path) as conn:
+    async with aiosqlite.connect(DB_PATH) as conn:
         # Config table
         await conn.execute('''
             CREATE TABLE IF NOT EXISTS config (

--- a/core/initialisation.py
+++ b/core/initialisation.py
@@ -1,5 +1,4 @@
 import discord
-import os
 import datetime
 import aiosqlite
 import logging
@@ -8,13 +7,12 @@ from discord import app_commands
 from discord.ext import commands
 
 from config import client
+from core.utils import DB_PATH
 
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-os.makedirs('./data/databases', exist_ok=True)
-db_path = './data/databases/pebble.db'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -34,7 +32,7 @@ class TheMachineBotCore(commands.Cog):
     @commands.Cog.listener()
     async def on_ready(self):
         print(f'Logged on as {self.bot.user}...')
-        async with aiosqlite.connect(db_path) as conn:
+        async with aiosqlite.connect(DB_PATH) as conn:
             async with conn.execute('SELECT value FROM customisation WHERE type = ?', ("activity_type",)) as cursor:
                 activity_type_doc = await cursor.fetchone()
             async with conn.execute('SELECT value FROM customisation WHERE type = ?', ("bio",)) as cursor:

--- a/core/utils.py
+++ b/core/utils.py
@@ -8,8 +8,13 @@ from discord.ui import View, Button
 # ---------------------------------------------------------------------------------------------------------------------
 # Database Configuration
 # ---------------------------------------------------------------------------------------------------------------------
-os.makedirs('./data/databases', exist_ok=True)
-db_path = './data/databases/pebble.db'
+DB_DIR = os.path.join('data', 'databases')
+DB_PATH = os.path.join(DB_DIR, 'pebble.db')
+os.makedirs(DB_DIR, exist_ok=True)
+
+def get_db_path() -> str:
+    """Return the location of the bot's SQLite database."""
+    return DB_PATH
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -22,7 +27,7 @@ logger = logging.getLogger(__name__)
 async def get_embed_colour(guild_id):
     try:
         guild_id = int(guild_id)
-        async with aiosqlite.connect(db_path) as conn:
+        async with aiosqlite.connect(DB_PATH) as conn:
             async with conn.execute(
                 'SELECT value FROM customisation WHERE type = ? AND guild_id = ?',
                 ("embed_color", guild_id)
@@ -59,8 +64,8 @@ async def log_command_usage(bot, interaction):
         log_channel = None
 
         if guild:
-            async with aiosqlite.connect(db_path) as conn:
-                logger.info(f"Connected to the database at {db_path}")
+            async with aiosqlite.connect(DB_PATH) as conn:
+                logger.info(f"Connected to the database at {DB_PATH}")
                 async with conn.execute(
                     'SELECT log_channel_id FROM config WHERE guild_id = ?', (guild.id,)
                 ) as cursor:
@@ -110,7 +115,7 @@ async def check_permissions(interaction):
     if interaction.user.guild_permissions.administrator:
         return True
 
-    async with aiosqlite.connect(db_path) as conn:
+    async with aiosqlite.connect(DB_PATH) as conn:
         cursor = await conn.execute('''
             SELECT can_use_commands FROM permissions WHERE guild_id = ? AND user_id = ?
         ''', (interaction.guild_id, interaction.user.id))


### PR DESCRIPTION
## Summary
- add a single DB_PATH helper in `core.utils`
- reference `DB_PATH` across cogs and bot code
- clean up duplicate `os.makedirs` calls

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845814a0bb88323bd3173fdf50b2dbf